### PR TITLE
Auto-complete support for docs command, query option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>4.3.0_300</version>
+      <version>5.0.0-alpha.9</version>
     </dependency>
 
     <dependency>
@@ -89,11 +89,6 @@
   </dependencies>
 
   <repositories>
-    <repository>
-      <id>dv8tion</id>
-      <name>m2-dv8tion</name>
-      <url>https://m2.dv8tion.net/releases</url>
-    </repository>
     <repository>
         <id>jitpack.io</id>
         <url>https://jitpack.io</url>

--- a/src/main/java/de/ialistannen/doctor/Main.java
+++ b/src/main/java/de/ialistannen/doctor/Main.java
@@ -67,7 +67,7 @@ public class Main {
         .setRequiredScopes("applications.commands", "bot")
         .awaitReady();
 
-    System.out.println(jda.getInviteUrl(Permission.MESSAGE_WRITE));
+    System.out.println(jda.getInviteUrl(Permission.MESSAGE_SEND));
   }
 
   private static List<ExternalJavadocReference> indexExternalJavadoc(List<String> urls)

--- a/src/main/java/de/ialistannen/doctor/commands/DocCommand.java
+++ b/src/main/java/de/ialistannen/doctor/commands/DocCommand.java
@@ -1,17 +1,6 @@
 package de.ialistannen.doctor.commands;
 
-import static de.ialistannen.doctor.util.parsers.ArgumentParsers.integer;
-import static de.ialistannen.doctor.util.parsers.ArgumentParsers.literal;
-import static de.ialistannen.doctor.util.parsers.ArgumentParsers.remaining;
-import static de.ialistannen.doctor.util.parsers.ArgumentParsers.word;
-import static java.util.stream.Collectors.toList;
-
-import de.ialistannen.doctor.commands.system.ButtonCommandSource;
-import de.ialistannen.doctor.commands.system.Command;
-import de.ialistannen.doctor.commands.system.CommandContext;
-import de.ialistannen.doctor.commands.system.CommandSource;
-import de.ialistannen.doctor.commands.system.SelectionMenuCommandSource;
-import de.ialistannen.doctor.commands.system.SlashCommandSource;
+import de.ialistannen.doctor.commands.system.*;
 import de.ialistannen.doctor.doc.DocMultipleResultSender;
 import de.ialistannen.doctor.doc.DocResultSender;
 import de.ialistannen.doctor.messages.MessageSender;
@@ -26,16 +15,17 @@ import de.ialistannen.javadocapi.querying.QueryApi;
 import de.ialistannen.javadocapi.storage.ElementLoader;
 import de.ialistannen.javadocapi.storage.ElementLoader.LoadResult;
 import de.ialistannen.javadocapi.util.BaseUrlElementLoader;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+import static de.ialistannen.doctor.util.parsers.ArgumentParsers.*;
+import static java.util.stream.Collectors.toList;
 
 public class DocCommand implements Command {
 
@@ -63,7 +53,7 @@ public class DocCommand implements Command {
   @Override
   public Optional<CommandData> getSlashData() {
     return Optional.of(
-        new CommandData(
+        Commands.slash(
             "doc",
             "Fetches Javadoc for methods, classes and fields."
         )

--- a/src/main/java/de/ialistannen/doctor/commands/system/AutoCompleteCommandSource.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/AutoCompleteCommandSource.java
@@ -1,0 +1,33 @@
+package de.ialistannen.doctor.commands.system;
+
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+
+public class AutoCompleteCommandSource implements CommandSource {
+    private final CommandAutoCompleteInteractionEvent event;
+
+    public AutoCompleteCommandSource(CommandAutoCompleteInteractionEvent event) {
+        this.event = event;
+    }
+
+    public CommandAutoCompleteInteractionEvent getEvent() {
+        return event;
+    }
+
+    public String getOptionName() {
+        return event.getFocusedOption().getName();
+    }
+
+    public String getOptionValue() {
+        return event.getFocusedOption().getValue();
+    }
+
+    @Override
+    public String getAuthorId() {
+        return event.getInteraction().getUser().getId();
+    }
+
+    @Override
+    public String getId() {
+        return event.getId();
+    }
+}

--- a/src/main/java/de/ialistannen/doctor/commands/system/ButtonCommandSource.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/ButtonCommandSource.java
@@ -1,16 +1,16 @@
 package de.ialistannen.doctor.commands.system;
 
-import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 
 public class ButtonCommandSource implements CommandSource {
 
-  private final ButtonClickEvent event;
+  private final ButtonInteractionEvent event;
 
-  public ButtonCommandSource(ButtonClickEvent event) {
+  public ButtonCommandSource(ButtonInteractionEvent event) {
     this.event = event;
   }
 
-  public ButtonClickEvent getEvent() {
+  public ButtonInteractionEvent getEvent() {
     return event;
   }
 

--- a/src/main/java/de/ialistannen/doctor/commands/system/Command.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/Command.java
@@ -2,8 +2,9 @@ package de.ialistannen.doctor.commands.system;
 
 import de.ialistannen.doctor.messages.MessageSender;
 import de.ialistannen.doctor.util.parsers.ArgumentParser;
-import java.util.Optional;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+
+import java.util.Optional;
 
 public interface Command {
 
@@ -25,6 +26,8 @@ public interface Command {
       handle(commandContext, (SlashCommandSource) source, sender);
     } else if (source instanceof SelectionMenuCommandSource) {
       handle(commandContext, (SelectionMenuCommandSource) source, sender);
+    } else if (source instanceof AutoCompleteCommandSource) {
+      handle(commandContext, (AutoCompleteCommandSource) source, sender);
     }
   }
 
@@ -45,6 +48,11 @@ public interface Command {
 
   default void handle(CommandContext commandContext, SlashCommandSource source,
       MessageSender sender) {
+    handle(commandContext, (CommandSource) source, sender);
+  }
+
+  default void handle(CommandContext commandContext, AutoCompleteCommandSource source,
+                      MessageSender sender) {
     handle(commandContext, (CommandSource) source, sender);
   }
 }

--- a/src/main/java/de/ialistannen/doctor/commands/system/Executor.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/Executor.java
@@ -7,11 +7,13 @@ import de.ialistannen.doctor.util.parsers.ParseError;
 import de.ialistannen.doctor.util.parsers.StringReader;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.CommandAutoCompleteInteraction;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenuInteraction;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,6 +54,28 @@ public class Executor extends ListenerAdapter {
         )
     );
   }
+
+
+  @Override
+  public void onCommandAutoCompleteInteraction(@NotNull final CommandAutoCompleteInteractionEvent event) {
+    CommandAutoCompleteInteraction interaction = event.getInteraction();
+
+    StringReader reader = new StringReader("!" + event.getName() + " ");
+    Optional<Command> command = findCommand(reader);
+
+    if (command.isEmpty()) {
+      event.replyChoices(Collections.emptyList()).queue();
+      return;
+    }
+
+    MessageSender sender = new InitialInteractionMessageSender(interaction);
+    AutoCompleteCommandSource source = new AutoCompleteCommandSource(event);
+    handleCommandError(
+            sender,
+            () -> command.get().handle(new CommandContext(reader), source, sender)
+    );
+  }
+
 
   @Override
   public void onSelectMenuInteraction(@NotNull SelectMenuInteractionEvent event) {

--- a/src/main/java/de/ialistannen/doctor/commands/system/Executor.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/Executor.java
@@ -5,19 +5,20 @@ import de.ialistannen.doctor.messages.MessageSender;
 import de.ialistannen.doctor.messages.NormalMessageSender;
 import de.ialistannen.doctor.util.parsers.ParseError;
 import de.ialistannen.doctor.util.parsers.StringReader;
-import java.awt.Color;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.selections.SelectMenuInteraction;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
-import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
-import net.dv8tion.jda.api.events.interaction.SelectionMenuEvent;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.selections.SelectionMenuInteraction;
-import org.jetbrains.annotations.NotNull;
 
 public class Executor extends ListenerAdapter {
 
@@ -53,8 +54,8 @@ public class Executor extends ListenerAdapter {
   }
 
   @Override
-  public void onSelectionMenu(@NotNull SelectionMenuEvent event) {
-    SelectionMenuInteraction interaction = event.getInteraction();
+  public void onSelectMenuInteraction(@NotNull SelectMenuInteractionEvent event) {
+    SelectMenuInteraction interaction = event.getInteraction();
     if (interaction.getValues().size() != 1) {
       event.reply("Sorry, I can't really handle multiple/none options right now.")
           .setEphemeral(true)
@@ -78,7 +79,7 @@ public class Executor extends ListenerAdapter {
   }
 
   @Override
-  public void onButtonClick(@NotNull ButtonClickEvent event) {
+  public void onButtonInteraction(@NotNull ButtonInteractionEvent event) {
     if (event.getButton() == null) {
       event.reply("Unknown button :/").queue();
       return;
@@ -105,7 +106,7 @@ public class Executor extends ListenerAdapter {
   }
 
   @Override
-  public void onSlashCommand(@NotNull SlashCommandEvent event) {
+  public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
     StringReader reader = new StringReader("!" + event.getName() + " ");
 
     Optional<Command> command = findCommand(reader);

--- a/src/main/java/de/ialistannen/doctor/commands/system/SelectionMenuCommandSource.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/SelectionMenuCommandSource.java
@@ -1,16 +1,16 @@
 package de.ialistannen.doctor.commands.system;
 
-import net.dv8tion.jda.api.events.interaction.SelectionMenuEvent;
+import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 
 public class SelectionMenuCommandSource implements CommandSource {
 
-  private final SelectionMenuEvent event;
+  private final SelectMenuInteractionEvent event;
 
-  public SelectionMenuCommandSource(SelectionMenuEvent event) {
+  public SelectionMenuCommandSource(SelectMenuInteractionEvent event) {
     this.event = event;
   }
 
-  public SelectionMenuEvent getEvent() {
+  public SelectMenuInteractionEvent getEvent() {
     return event;
   }
 

--- a/src/main/java/de/ialistannen/doctor/commands/system/SlashCommandSource.java
+++ b/src/main/java/de/ialistannen/doctor/commands/system/SlashCommandSource.java
@@ -1,18 +1,19 @@
 package de.ialistannen.doctor.commands.system;
 
 import java.util.Optional;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 
 public class SlashCommandSource implements CommandSource {
 
-  private final SlashCommandEvent event;
+  private final SlashCommandInteractionEvent event;
 
-  public SlashCommandSource(SlashCommandEvent event) {
+  public SlashCommandSource(SlashCommandInteractionEvent event) {
     this.event = event;
   }
 
-  public SlashCommandEvent getEvent() {
+  public SlashCommandInteractionEvent getEvent() {
     return event;
   }
 

--- a/src/main/java/de/ialistannen/doctor/doc/DocMultipleResultSender.java
+++ b/src/main/java/de/ialistannen/doctor/doc/DocMultipleResultSender.java
@@ -1,11 +1,5 @@
 package de.ialistannen.doctor.doc;
 
-import static de.ialistannen.doctor.util.StreamUtils.partition;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-
 import de.ialistannen.doctor.commands.system.CommandSource;
 import de.ialistannen.doctor.messages.MessageSender;
 import de.ialistannen.doctor.state.ActiveInteractions;
@@ -15,24 +9,23 @@ import de.ialistannen.javadocapi.model.QualifiedName;
 import de.ialistannen.javadocapi.querying.FuzzyQueryResult;
 import de.ialistannen.javadocapi.querying.QueryResult.ElementType;
 import de.ialistannen.javadocapi.util.NameShortener;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.Button;
-import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.dv8tion.jda.api.interactions.components.Component.Type;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
 import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
-import net.dv8tion.jda.api.interactions.components.selections.SelectionMenu;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import static de.ialistannen.doctor.util.StreamUtils.partition;
+import static java.util.stream.Collectors.*;
 
 public class DocMultipleResultSender {
 
@@ -159,7 +152,7 @@ public class DocMultipleResultSender {
     return grouped.entrySet().stream()
         .limit(5)
         .map(it ->
-            SelectionMenu.create("!javadoc " + source.getId() + " " + counter.counter++)
+            SelectMenu.create("!javadoc " + source.getId() + " " + counter.counter++)
                 .addOptions(it.getValue().stream().limit(25).collect(toList()))
                 .setPlaceholder(StringUtils.capitalize(it.getKey().name().toLowerCase(Locale.ROOT)))
                 .build()

--- a/src/main/java/de/ialistannen/doctor/doc/DocResultSender.java
+++ b/src/main/java/de/ialistannen/doctor/doc/DocResultSender.java
@@ -13,15 +13,16 @@ import de.ialistannen.javadocapi.rendering.LinkResolveStrategy;
 import de.ialistannen.javadocapi.rendering.MarkdownCommentRenderer;
 import de.ialistannen.javadocapi.storage.ElementLoader.LoadResult;
 import de.ialistannen.javadocapi.util.BaseUrlElementLoader;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.Button;
-import net.dv8tion.jda.api.interactions.components.ButtonStyle;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DocResultSender {
 


### PR DESCRIPTION
This PR adds auto-complete support to the docs command.

## Dependency upgrades
JDA has been upgraded to alpha 9 of v5.
stable release, but next update it might receive breaking changes.

## System changes:
Added AutoCompleteCommandSource 
Added Command#handle(CommandContext, AutoCompleteCommandSource, MessageSender)
Added Executor#onCommandAutoCompleteInteraction

## Doc command changes
Added handleAutoCompleteQuery which handles the autocomplete


## Todo's for in the future
- Implement fuzzy search